### PR TITLE
Fix metadata related to supported platforms.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,12 +8,12 @@ galaxy_info:
     - name: Debian
       versions:
         - jessie
-    - name: Darwin
-      versions:
-        - all
     - name: Ubuntu
       versions:
         - trusty
+    - name: MacOSX
+      versions:
+        - all
 
   galaxy_tags:
     - development


### PR DESCRIPTION
FYI: https://galaxy.ansible.com/api/v1/platforms/

- Now, MacOS is used instead of Darwin.